### PR TITLE
Add memory barrier to prevent optimization of read_line()

### DIFF
--- a/uart/ps5_uart.cpp
+++ b/uart/ps5_uart.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <atomic>
 #include <cstring>
 #include <format>
 #include <list>
@@ -121,7 +122,7 @@ struct Buffer {
   constexpr bool empty() const { return rpos == wpos; }
   bool read_line(std::string* line) {
     // purposefully done before masking irqs...should be fine?
-    // TODO reports of this this breaking exploit (on clang...)
+    std::atomic_signal_fence(std::memory_order_acquire);
     if (!num_newlines || empty()) {
       return false;
     }


### PR DESCRIPTION
Was hitting a bug where `read_line()` would always timeout and never actually read a line. I believe this was happening due to compiler optimizations since the compiler doesn't know that `num_newlines` can be written to by IRQ. Possibly addresses the TODO at top of `read_line()`, not sure if that is referencing this same issue.

Changing increments/decrements was necessary to fix this error:
```
ps5_uart.cpp:199:7: error: '++' expression of 'volatile'-qualified type is deprecated [-Werror=volatile]
  199 |       num_newlines++;
```

Changing the assignments in `clear()` to multiple lines was necessary to fix this error:
```
ps5-uart/uart/ps5_uart.cpp:211:32: error: using value of assignment with 'volatile'-qualified left operand is deprecated [-Werror=volatile]
  211 |     wpos = rpos = num_newlines = {};
```